### PR TITLE
Some shells (fish) use unicode in output

### DIFF
--- a/gsh/plugins/hooks/printer_hook.py
+++ b/gsh/plugins/hooks/printer_hook.py
@@ -6,6 +6,7 @@ def update_host_handler(hostname, stream, line, prepend_host=False):
         if stream not in ("stdout", "stderr"):
             return
         writer = getattr(sys, stream)
+        line = line.decode('utf-8')
         if prepend_host:
             line = "%s: %s" % (hostname, line)
         try:


### PR DESCRIPTION
If we try to use a string and get a unicode error, instead try decoding
that string as UTF-8.
