### PR TITLE
Bump gevent-subprocess for python 2.7 support

### DIFF
--- a/README
+++ b/README
@@ -23,6 +23,9 @@ easy as:
 
     pip install gsh
 
+On Debian/Ubuntu systems you will need the "python-dev" and "libevent-dev"
+packages installed.
+
 Examples
 ~~~~~~~~
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 PyYAML
 annex==0.2
 gevent==0.13.8
-gevent-subprocess==0.1.1
+gevent-subprocess==0.1.2
 greenlet==0.4.1


### PR DESCRIPTION
I verified that installing gevent-subprocess 0.1.2 (@gmjosack's change from https://github.com/bombela/gevent_subprocess/pull/3) fixed compatibility with python 2.7.

Also added an installation note for Debian/Ubuntu.
